### PR TITLE
Set default empty values in lira config

### DIFF
--- a/config_files/lira-config.json.ctmpl
+++ b/config_files/lira-config.json.ctmpl
@@ -31,7 +31,7 @@
     "submit_wdl": "{{ env "SUBMIT_WDL" }}",
     "wdls": [
         {
-            "analysis_wdls": {{ env "TENX_ANALYSIS_WDLS" }},
+            "analysis_wdls": {{ or (env "TENX_ANALYSIS_WDLS") "[]" }},
             "options_link": "{{ env "TENX_OPTIONS_LINK" }}",
             "subscription_id": "{{ env "TENX_SUBSCRIPTION_ID" }}",
             "wdl_static_inputs_link": "{{ env "TENX_WDL_STATIC_INPUTS_LINK" }}",
@@ -40,7 +40,7 @@
             "workflow_version": "{{ env "TENX_VERSION" }}"
         },
         {
-            "analysis_wdls": {{ env "SS2_ANALYSIS_WDLS" }},
+            "analysis_wdls": {{ or (env "SS2_ANALYSIS_WDLS") "[]" }},
             "options_link": "{{ env "SS2_OPTIONS_LINK" }}",
             "subscription_id": "{{ env "SS2_SUBSCRIPTION_ID" }}",
             "wdl_static_inputs_link": "{{ env "SS2_WDL_STATIC_INPUTS_LINK" }}",
@@ -49,7 +49,7 @@
             "workflow_version": "{{ env "SS2_VERSION" }}"
         },
         {
-            "analysis_wdls": {{ env "OPTIMUS_ANALYSIS_WDLS" }},
+            "analysis_wdls": {{ or (env "OPTIMUS_ANALYSIS_WDLS") "[]" }},
             "options_link": "{{ env "OPTIMUS_OPTIONS_LINK" }}",
             "subscription_id": "{{ env "OPTIMUS_SUBSCRIPTION_ID" }}",
             "wdl_static_inputs_link": "{{ env "OPTIMUS_WDL_STATIC_INPUTS_LINK" }}",


### PR DESCRIPTION
Purpose
---------
If no analysis WDL files are passed into the lira-config.json template, when it is rendered it will not have a value for those keys and the JSON file will be invalid. This causes the mintegration test to fail when it tries to run Lira because the test is not yet passing in values for Optimus when rendering the config.

Changes
---------
Set the analysis file keys to an empty array so that the JSON is still valid. 

Testing
--------
To verify that this change fixes the integration test:
1. Clone https://github.com/HumanCellAtlas/secondary-analysis
2. In secondary-analysis/tests/integration_test/run_int_test_locally.sh, change the SECONDARY_ANALYSIS_VERSION to `se-update-lira-config`
3. Run bash run_int_test_locally.sh <path_to_cloned_secondary_analysis_repo>
4. Confirm that a workflow runs successfully in Lira