### PR TITLE
Add kubernetes liveness probe to Falcon deployment

### DIFF
--- a/config_files/config.sh.ctmpl
+++ b/config_files/config.sh.ctmpl
@@ -10,7 +10,7 @@ export PIPELINE_TOOLS_VERSION="v0.48.1"
 
 export LIRA_VERSION="v0.19.0"
 
-export FALCON_VERSION="v0.2.0"
+export FALCON_VERSION="v0.3.0"
 
 export SS2_VERSION="smartseq2_v2.2.0"
 

--- a/config_files/falcon-deployment.yaml.ctmpl
+++ b/config_files/falcon-deployment.yaml.ctmpl
@@ -21,6 +21,13 @@ spec:
               image: {{env "FALCON_DOCKER_IMAGE"}}
               imagePullPolicy: Always
 
+              livenessProbe:
+                httpGet:
+                  path: /health
+                  port: 8000
+                initialDelaySeconds: 60
+                periodSeconds: 10
+
               volumeMounts:
                   - name: falcon-config
                     mountPath: /etc/falcon


### PR DESCRIPTION
Purpose:
---------
Fixes https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-103

> Falcon has 2 threads running in the background, Igniter and QueueHandler, the application will break and hang there if any of them is dead. we need a way to make sure the Falcon restart itself if it becomes unhealthy.

Changes:
---------
Add liveness probe to the Falcon deployment that uses the health check endpoint so that Kubernetes can restart the pod if any of the threads are not running. The probe is set to run every 10 seconds after an initial delay of 15 seconds.

Documentation here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes

Review Instructions:
---------
Please review the health check parameters

The configuration can be seen in the gcloud console for Falcon in the dev environment here: https://console.cloud.google.com/kubernetes/pod/us-central1-a/green-100-us-central1/green-100-us-central1-ns/falcon-7f9dddc55d-8md95?project=broad-dsde-mint-dev&container_summary_list_tablesize=10&tab=details&duration=PT1H&service_list_datatablesize=20&selectedType=c&selectedName=falcon