### PR TITLE
Update pipeline-tools version

### DIFF
--- a/config_files/config.sh.ctmpl
+++ b/config_files/config.sh.ctmpl
@@ -6,7 +6,7 @@
 
 source "${CONFIG_DIR}/environment.${ENVIRONMENT}"
 
-export PIPELINE_TOOLS_VERSION="v0.48.1"
+export PIPELINE_TOOLS_VERSION="v0.48.2"
 
 export LIRA_VERSION="v0.19.0"
 


### PR DESCRIPTION
Use version of pipeline-tools that passes in the empty_drops analysis output into the submission wdl.