### PR TITLE
Revert pipeline-tools version

### DIFF
--- a/config_files/config.sh.ctmpl
+++ b/config_files/config.sh.ctmpl
@@ -6,7 +6,7 @@
 
 source "${CONFIG_DIR}/environment.${ENVIRONMENT}"
 
-export PIPELINE_TOOLS_VERSION="v0.51.1"
+export PIPELINE_TOOLS_VERSION="v0.50.2"
 
 export LIRA_VERSION="v0.20.0"
 


### PR DESCRIPTION
- Version v0.51.1 removes the gtf_file input to SmartSeq2, so it must be released with a new version of SmartSeq2 that does not require that parameter