### PR TITLE
Testing branch of pipeline-tools

### DIFF
--- a/config_files/config.sh.ctmpl
+++ b/config_files/config.sh.ctmpl
@@ -8,7 +8,7 @@ source "${CONFIG_DIR}/environment.${ENVIRONMENT}"
 
 export PIPELINE_TOOLS_VERSION="v0.56.1"
 
-export LIRA_VERSION="v0.20.0"
+export LIRA_VERSION="se-test-pipeline-tools-changes"
 
 export FALCON_VERSION="v0.4.1"
 


### PR DESCRIPTION
This branch removes data file checkout when only downloading metadata to reduce the amount of time it takes to generate a hash based on bundle inputs.