### PR TITLE
Add test_mode flag to lira config

### DIFF
--- a/config_files/config.sh.ctmpl
+++ b/config_files/config.sh.ctmpl
@@ -53,6 +53,7 @@ export GCS_ROOT="gs://${GCLOUD_PROJECT}-cromwell-execution/caas-cromwell-executi
 export USE_HMAC=true
 export SUBMIT_WDL_DIR=""
 export SUBMIT_AND_HOLD=true
+export TEST_MODE=false
 
 export CAAS_KEY_PATH="secret/dsde/mint/${ENVIRONMENT}/${LIRA_APPLICATION_NAME}/${CAAS_KEY_FILE}"
 

--- a/config_files/lira-config.json.ctmpl
+++ b/config_files/lira-config.json.ctmpl
@@ -17,6 +17,7 @@
     "MAX_CONTENT_LENGTH": 10000,
     "use_caas": {{ env "USE_CAAS" | parseBool }},
     "submit_and_hold": {{ env "SUBMIT_AND_HOLD" | parseBool }},
+    "test_mode": {{ env "TEST_MODE" | parseBool }},
     "env": "{{ $ENVIRONMENT }}",
     "google_project": "{{ env "GCLOUD_PROJECT" }}",
     "google_pubsub_topic": "{{ env "GOOGLE_PUBSUB_TOPIC" }}",


### PR DESCRIPTION
Add a config variable that can be enabled by the mintegration tests to bypass checking that messages are coming from google pub/sub, since it tests lira by running it locally.