### PR TITLE
Add autoscaling to Lira deployment

### DIFF
--- a/config_files/config.sh.ctmpl
+++ b/config_files/config.sh.ctmpl
@@ -37,7 +37,6 @@ export KUBERNETES_ZONE="us-central1-a"
 
 # Lira Variables
 
-export LIRA_NUMBER_OF_REPLICAS="3"
 export LIRA_APPLICATION_NAME="lira"
 export LIRA_DEPLOYMENT_NAME="lira"
 export LIRA_CONTAINER_NAME="lira"
@@ -47,6 +46,7 @@ export LIRA_INGRESS_NAME="lira-ingress"
 export LIRA_CONFIG_FILE="lira-config.json"
 export LIRA_CONFIG_SECRET_NAME="lira-config-$(date '+%Y-%m-%d-%H-%M-%S')"
 export LIRA_DEPLOYMENT_YAML="lira-deployment.yaml"
+
 export LIRA_DOCKER_IMAGE="quay.io/humancellatlas/secondary-analysis-lira:${LIRA_VERSION}"
 export GCS_ROOT="gs://${GCLOUD_PROJECT}-cromwell-execution/caas-cromwell-executions"
 
@@ -56,6 +56,13 @@ export SUBMIT_AND_HOLD=true
 export TEST_MODE=false
 
 export CAAS_KEY_PATH="secret/dsde/mint/${ENVIRONMENT}/${LIRA_APPLICATION_NAME}/${CAAS_KEY_FILE}"
+
+# Lira Autoscaling Variables
+export LIRA_AUTOSCALER_NAME="lira-autoscaler"
+export LIRA_MIN_REPLICAS="2"
+export LIRA_MAX_REPLICAS="6"
+export LIRA_PERCENT_TARGET_CPU_USAGE=75"
+
 
 # Falcon Variables
 

--- a/config_files/config.sh.ctmpl
+++ b/config_files/config.sh.ctmpl
@@ -46,7 +46,6 @@ export LIRA_INGRESS_NAME="lira-ingress"
 export LIRA_CONFIG_FILE="lira-config.json"
 export LIRA_CONFIG_SECRET_NAME="lira-config-$(date '+%Y-%m-%d-%H-%M-%S')"
 export LIRA_DEPLOYMENT_YAML="lira-deployment.yaml"
-
 export LIRA_DOCKER_IMAGE="quay.io/humancellatlas/secondary-analysis-lira:${LIRA_VERSION}"
 export GCS_ROOT="gs://${GCLOUD_PROJECT}-cromwell-execution/caas-cromwell-executions"
 

--- a/config_files/lira-autoscaler.yaml.ctmpl
+++ b/config_files/lira-autoscaler.yaml.ctmpl
@@ -1,0 +1,12 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ env "LIRA_AUTOSCALER_NAME" }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ env "LIRA_DEPLOYMENT_NAME" }}
+  minReplicas: {{ env "LIRA_MIN_REPLICAS" }}
+  maxReplicas: {{ env "LIRA_MAX_REPLICAS" }}
+  targetCPUUtilizationPercentage: {{ env "LIRA_PERCENT_TARGET_CPU_USAGE" }}

--- a/config_files/lira-deployment.yaml.ctmpl
+++ b/config_files/lira-deployment.yaml.ctmpl
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
     name: {{ env "LIRA_DEPLOYMENT_NAME" }}
 spec:
-    replicas: {{ env "LIRA_NUMBER_OF_REPLICAS" }}
     template:
         metadata:
             labels:
@@ -38,7 +37,9 @@ spec:
                   timeoutSeconds: 5
                   successThreshold: 1
                   failureThreshold: 10
-
+            resources:
+                requests:
+                    cpu: "1"
             terminationGracePeriodSeconds: 0
             volumes:
                 - name: lira-config

--- a/gitlab/deploy_lira.sh
+++ b/gitlab/deploy_lira.sh
@@ -141,3 +141,13 @@ echo "Deploying Lira"
 kubectl apply -f "${CONFIG_DIR}/${LIRA_DEPLOYMENT_YAML}" \
               --record \
               --namespace "${KUBERNETES_NAMESPACE}"
+
+echo "Generating Lira autoscaler file"
+sh "${DEPLOY_DIR}/render-ctmpls.sh" -k "${CONFIG_DIR}/lira-autoscaler.yaml.ctmpl"
+
+cat "${CONFIG_DIR}/lira-autoscaler.yaml.ctmpl"
+
+echo "Updating Lira autoscaler"
+kubectl apply -f "${CONFIG_DIR}/lira-autoscaler.yaml.ctmpl" \
+              --record \
+              --namespace "${KUBERNETES_NAMESPACE}"


### PR DESCRIPTION
Kubernetes has a feature for automatically scaling up (or down) the number of deployment replicas based on specific metrics such as CPU usage. This PR updates the lira deployment script to include this autoscaling behavior.