### PR TITLE
Set requested memory for Lira deployment

### DIFF
--- a/config_files/lira-deployment.yaml.ctmpl
+++ b/config_files/lira-deployment.yaml.ctmpl
@@ -40,6 +40,7 @@ spec:
               resources:
                   requests:
                       cpu: "0.25"
+                      memory: "1G"
             terminationGracePeriodSeconds: 0
             volumes:
                 - name: lira-config


### PR DESCRIPTION
The integration deployment has a [node](https://console.cloud.google.com/kubernetes/node/us-central1-a/green-100-us-central1/gke-green-100-us-cen-green-node-pool--be54b5ea-wd39?project=broad-dsde-mint-integration&organizationId=548622027621&tab=summary&duration=P7D&pod_summary_list_tablesize=20) where several Lira pods were evicted due to lack of available memory. By requesting a certain amount of memory by default (instead of 0), this should prevent Kubernetes from scheduling a pod in a node that may be close to capacity.

More info here: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-requests-are-scheduled

Note: In production, which does not yet have autoscaling, we have 3 Lira pods all on the same node, and I haven't seen any pods get evicted because the node ran out of memory 🤔 But perhaps we only reached that point in our integration scaling tests, and not while running datasets in production.