### PR TITLE
Add monitoring image for dev & int

### DIFF
--- a/config_files/environment.dev
+++ b/config_files/environment.dev
@@ -13,6 +13,7 @@ export OPTIMUS_SUBSCRIPTION_ID="placeholder_optimus_subscription_id"
 
 export GCLOUD_PROJECT="broad-dsde-mint-dev"
 export GOOGLE_PUBSUB_TOPIC="hca-notifications-${ENVIRONMENT}"
+export MONITORING_IMAGE="us.gcr.io/broad-dsde-mint-dev/cromwell-task-monitor-bq"
 
 export DSS_URL="https://dss.dev.data.humancellatlas.org/v1"
 export SCHEMA_URL="https://schema.dev.data.humancellatlas.org/"

--- a/config_files/environment.integration
+++ b/config_files/environment.integration
@@ -13,6 +13,7 @@ export OPTIMUS_SUBSCRIPTION_ID="65dc209f-99e8-449c-89c9-c37ac9921648"
 
 export GCLOUD_PROJECT="broad-dsde-mint-integration"
 export GOOGLE_PUBSUB_TOPIC="hca-notifications-${ENVIRONMENT}"
+export MONITORING_IMAGE="us.gcr.io/broad-dsde-mint-integration/cromwell-task-monitor-bq"
 
 export DSS_URL="https://dss.integration.data.humancellatlas.org/v1"
 export SCHEMA_URL="https://schema.integration.data.humancellatlas.org/"

--- a/config_files/lira-config.json.ctmpl
+++ b/config_files/lira-config.json.ctmpl
@@ -30,7 +30,7 @@
     "notification_token": "{{ $liraSecret.Data.notification_token }}",
 {{ end }}
     "max_cromwell_retries": "{{ env "MAX_CROMWELL_RETRIES" }}",
-    "monitoring_image": "{{ env "MONITORING_IMAGE" }}",
+    "monitoring_image": "{{ or (env "MONITORING_IMAGE") null }}",
     "submit_wdl": "{{ env "SUBMIT_WDL" }}",
     "wdls": [
         {

--- a/config_files/lira-config.json.ctmpl
+++ b/config_files/lira-config.json.ctmpl
@@ -30,7 +30,7 @@
     "notification_token": "{{ $liraSecret.Data.notification_token }}",
 {{ end }}
     "max_cromwell_retries": "{{ env "MAX_CROMWELL_RETRIES" }}",
-    "monitoring_image": "{{ or (env "MONITORING_IMAGE") null }}",
+    "monitoring_image": "{{ env "MONITORING_IMAGE" }}",
     "submit_wdl": "{{ env "SUBMIT_WDL" }}",
     "wdls": [
         {

--- a/config_files/lira-config.json.ctmpl
+++ b/config_files/lira-config.json.ctmpl
@@ -30,6 +30,7 @@
     "notification_token": "{{ $liraSecret.Data.notification_token }}",
 {{ end }}
     "max_cromwell_retries": "{{ env "MAX_CROMWELL_RETRIES" }}",
+    "monitoring_image": "{{ env "MONITORING_IMAGE" }}",
     "submit_wdl": "{{ env "SUBMIT_WDL" }}",
     "wdls": [
         {


### PR DESCRIPTION
Because the monitoring image is stored in gcr and is environment-specific, add it to the environment-specific config files for Lira.

Note: Starting with dev and integration for testing