### PR TITLE
Adjust Lira's requested CPU

### DIFF
--- a/config_files/lira-deployment.yaml.ctmpl
+++ b/config_files/lira-deployment.yaml.ctmpl
@@ -39,7 +39,7 @@ spec:
                   failureThreshold: 10
               resources:
                   requests:
-                      cpu: "0.25"
+                      cpu: "0.20"
                       memory: "1G"
             terminationGracePeriodSeconds: 0
             volumes:


### PR DESCRIPTION
Purpose:
--------
Each Kubernetes cluster we have is configured with a node-pool containing 3 nodes. (each with 940mCPU allocatable CPU and 2.77 GB allocatable memory)

Each Lira pod currently requests 250 mCPU and 1 GB memory. With the kube-system pods included, the node-pool only has enough CPU for a maximum of 4 Lira pods. This causes problems with the autoscaler, which sets a max of 6 Lira pods.

Changes:
---------
Since 250 mCPU was just a ball-park number to begin with, reduce the requested CPU to 200mCPU to accommodate 6 Lira pods. 

Note: If this ends up being too low, we can revert this change and instead rely on node auto-scaling