### PR TITLE
Add dry run option back into Lira config

### DIFF
--- a/config_files/environment.dev
+++ b/config_files/environment.dev
@@ -10,6 +10,7 @@ export TLS_CREATION_DRY_RUN="false"
 export SS2_SUBSCRIPTION_ID="placeholder_ss2_subscription_id"
 export TENX_SUBSCRIPTION_ID="placeholder_10x_subscription_id"
 export OPTIMUS_SUBSCRIPTION_ID="placeholder_optimus_subscription_id"
+export LIRA_DRY_RUN="true"
 
 export GCLOUD_PROJECT="broad-dsde-mint-dev"
 export GOOGLE_PUBSUB_TOPIC="hca-notifications-${ENVIRONMENT}"

--- a/config_files/lira-config.json.ctmpl
+++ b/config_files/lira-config.json.ctmpl
@@ -18,7 +18,7 @@
     "use_caas": {{ env "USE_CAAS" | parseBool }},
     "submit_and_hold": {{ env "SUBMIT_AND_HOLD" | parseBool }},
     "test_mode": {{ env "TEST_MODE" | parseBool }},
-    "dry_run": {{ or (env "DRY_RUN") "false" | parseBool }},
+    "dry_run": {{ or (env "LIRA_DRY_RUN") "false" | parseBool }},
     "env": "{{ $ENVIRONMENT }}",
     "google_project": "{{ env "GCLOUD_PROJECT" }}",
     "google_pubsub_topic": "{{ env "GOOGLE_PUBSUB_TOPIC" }}",

--- a/config_files/lira-config.json.ctmpl
+++ b/config_files/lira-config.json.ctmpl
@@ -18,6 +18,7 @@
     "use_caas": {{ env "USE_CAAS" | parseBool }},
     "submit_and_hold": {{ env "SUBMIT_AND_HOLD" | parseBool }},
     "test_mode": {{ env "TEST_MODE" | parseBool }},
+    "dry_run": {{ or (env "DRY_RUN") "false" | parseBool }},
     "env": "{{ $ENVIRONMENT }}",
     "google_project": "{{ env "GCLOUD_PROJECT" }}",
     "google_pubsub_topic": "{{ env "GOOGLE_PUBSUB_TOPIC" }}",


### PR DESCRIPTION
Lira will skip submitting a workflow to Cromwell if "dry_run" is set to `True` in the config. Add this back in so we can use it for load-testing Lira.